### PR TITLE
fix: Typo on pytest-isolate requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyinstaller==6.11.0
 flake8==7.1.1
 pytest==8.3.3
 pytest-qt==4.4.0
-pytest-isolate=0.0.2
+pytest-isolate==0.0.2


### PR DESCRIPTION
Typo on requirements.txt